### PR TITLE
.gitignore: ignore .docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 main
 dist/*
 packer-plugin-oneandone
+.docs


### PR DESCRIPTION
The .docs directory is generated, and should therefore not be tracked by Git.