### PR TITLE
Pinned missing actions

### DIFF
--- a/.github/workflows/notify-integration-release-via-manual.yaml
+++ b/.github/workflows/notify-integration-release-via-manual.yaml
@@ -19,7 +19,7 @@ jobs:
         with:
           ref: ${{ github.event.inputs.branch }}
       # Ensure that Docs are Compiled
-      - uses: actions/setup-go@v4
+      - uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
       - shell: bash
         run: make build-docs
       - shell: bash

--- a/.github/workflows/notify-integration-release-via-tag.yaml
+++ b/.github/workflows/notify-integration-release-via-tag.yaml
@@ -13,7 +13,7 @@ jobs:
         with:
           ref: ${{ github.ref }}
       # Ensure that Docs are Compiled
-      - uses: actions/setup-go@v4
+      - uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
       - shell: bash
         run: make build-docs
       - shell: bash


### PR DESCRIPTION
Pinning `actions/setup-go@v4` to commit hash `93397bea11091df50f3d7e59dc26a7711a8bcfbe`, which is tag `v4.1.0`.